### PR TITLE
Update multiple winners

### DIFF
--- a/puzzle_raffle/build/main.aleo
+++ b/puzzle_raffle/build/main.aleo
@@ -526,9 +526,9 @@ finalize draw_winner:
     get.or_use has_won[r3] false into r5;
     not r5 into r6;
     set true into has_won[r3];
-    set r3 into winner[r4];
     add r4 1u32 into r7;
     set r7 into winner_count[0u32];
+    set r3 into winner[r4];
 
 
 function draw_three_winners:
@@ -565,12 +565,21 @@ finalize draw_three_winners:
 function send_prize_to_winner:
     input r0 as address.public;
     input r1 as Prize.record;
+    input r2 as u32.public;
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
-    cast r0 r1.private_key into r2 as Prize.record;
-    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r0 r1.private_key into r3 as AuditPrizeToWinner.record;
-    output r2 as Prize.record;
-    output r3 as AuditPrizeToWinner.record;
+    cast r0 r1.private_key into r3 as Prize.record;
+    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r0 r1.private_key into r4 as AuditPrizeToWinner.record;
+    async send_prize_to_winner r0 r2 into r5;
+    output r3 as Prize.record;
+    output r4 as AuditPrizeToWinner.record;
+    output r5 as puzzle_raffle_050124.aleo/send_prize_to_winner.future;
+
+finalize send_prize_to_winner:
+    input r0 as address.public;
+    input r1 as u32.public;
+    get winner[r1] into r2;
+    assert.eq r0 r2;
 
 
 function send_three_prizes_to_winners:

--- a/puzzle_raffle/build/main.aleo
+++ b/puzzle_raffle/build/main.aleo
@@ -521,6 +521,26 @@ finalize draw_winner:
     get total_entries[0u64] into r0;
     rand.chacha into r1 as u64;
     rem r1 r0 into r2;
+    get entries[r2] into r3;
+    get.or_use winner_count[0u32] 0u32 into r4;
+    get.or_use has_won[r3] false into r5;
+    not r5 into r6;
+    set true into has_won[r3];
+    set r3 into winner[r4];
+    add r4 1u32 into r7;
+    set r7 into winner_count[0u32];
+
+
+function draw_three_winners:
+    assert.eq self.caller self.signer;
+    assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
+    async draw_three_winners into r0;
+    output r0 as puzzle_raffle_050124.aleo/draw_three_winners.future;
+
+finalize draw_three_winners:
+    get total_entries[0u64] into r0;
+    rand.chacha into r1 as u64;
+    rem r1 r0 into r2;
     set r2 into winner_idxs[0u32];
     rand.chacha into r3 as u64;
     rem r3 r0 into r4;
@@ -551,3 +571,35 @@ function send_prize_to_winner:
     cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r0 r1.private_key into r3 as AuditPrizeToWinner.record;
     output r2 as Prize.record;
     output r3 as AuditPrizeToWinner.record;
+
+
+function send_three_prizes_to_winners:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as address.public;
+    input r3 as u32.public;
+    input r4 as Prize.record;
+    input r5 as Prize.record;
+    input r6 as Prize.record;
+    assert.eq self.caller self.signer;
+    assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
+    cast r0 r4.private_key into r7 as Prize.record;
+    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r0 r4.private_key into r8 as AuditPrizeToWinner.record;
+    cast r1 r5.private_key into r9 as Prize.record;
+    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r1 r5.private_key into r10 as AuditPrizeToWinner.record;
+    cast r2 r6.private_key into r11 as Prize.record;
+    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r2 r6.private_key into r12 as AuditPrizeToWinner.record;
+    async send_three_prizes_to_winners r0 r1 r2 r3 into r13;
+    output r13 as puzzle_raffle_050124.aleo/send_three_prizes_to_winners.future;
+
+finalize send_three_prizes_to_winners:
+    input r0 as address.public;
+    input r1 as address.public;
+    input r2 as address.public;
+    input r3 as u32.public;
+    get winner_one[r3] into r4;
+    assert.eq r4 r0;
+    get winner_one[r3] into r5;
+    assert.eq r5 r1;
+    get winner_one[r3] into r6;
+    assert.eq r6 r2;

--- a/puzzle_raffle/build/main.aleo
+++ b/puzzle_raffle/build/main.aleo
@@ -504,10 +504,11 @@ finalize draw_winner:
     get entries[r2] into r3;
     get.or_use winner_count[0u32] 0u32 into r4;
     get.or_use has_won[r3] false into r5;
+    not r5 into r6;
     set true into has_won[r3];
     set r3 into winner[r4];
-    add r4 1u32 into r6;
-    set r6 into winner_count[0u32];
+    add r4 1u32 into r7;
+    set r7 into winner_count[0u32];
 
 
 function send_prize_to_winner:

--- a/puzzle_raffle/build/main.aleo
+++ b/puzzle_raffle/build/main.aleo
@@ -565,21 +565,19 @@ finalize draw_three_winners:
 function send_prize_to_winner:
     input r0 as address.public;
     input r1 as Prize.record;
-    input r2 as u32.public;
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
-    cast r0 r1.private_key into r3 as Prize.record;
-    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r0 r1.private_key into r4 as AuditPrizeToWinner.record;
-    async send_prize_to_winner r0 r2 into r5;
-    output r3 as Prize.record;
-    output r4 as AuditPrizeToWinner.record;
-    output r5 as puzzle_raffle_050124.aleo/send_prize_to_winner.future;
+    cast r0 r1.private_key into r2 as Prize.record;
+    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r0 r1.private_key into r3 as AuditPrizeToWinner.record;
+    async send_prize_to_winner r0 into r4;
+    output r2 as Prize.record;
+    output r3 as AuditPrizeToWinner.record;
+    output r4 as puzzle_raffle_050124.aleo/send_prize_to_winner.future;
 
 finalize send_prize_to_winner:
     input r0 as address.public;
-    input r1 as u32.public;
-    get winner[r1] into r2;
-    assert.eq r0 r2;
+    get.or_use has_won[r0] false into r1;
+    assert.eq r1 true;
 
 
 function send_three_prizes_to_winners:
@@ -608,7 +606,7 @@ finalize send_three_prizes_to_winners:
     input r3 as u32.public;
     get winner_one[r3] into r4;
     assert.eq r4 r0;
-    get winner_one[r3] into r5;
+    get winner_two[r3] into r5;
     assert.eq r5 r1;
-    get winner_one[r3] into r6;
+    get winner_three[r3] into r6;
     assert.eq r6 r2;

--- a/puzzle_raffle/build/main.aleo
+++ b/puzzle_raffle/build/main.aleo
@@ -34,6 +34,11 @@ mapping winner:
 	value as address.public;
 
 
+mapping has_won:
+	key as address.public;
+	value as boolean.public;
+
+
 mapping winner_count:
 	key as u32.public;
 	value as u32.public;
@@ -498,9 +503,11 @@ finalize draw_winner:
     rem r1 r0 into r2;
     get entries[r2] into r3;
     get.or_use winner_count[0u32] 0u32 into r4;
+    get.or_use has_won[r3] false into r5;
+    set true into has_won[r3];
     set r3 into winner[r4];
-    add r4 1u32 into r5;
-    set r5 into winner_count[0u32];
+    add r4 1u32 into r6;
+    set r6 into winner_count[0u32];
 
 
 function send_prize_to_winner:

--- a/puzzle_raffle/build/main.aleo
+++ b/puzzle_raffle/build/main.aleo
@@ -1,4 +1,4 @@
-program puzzle_single_draw_raffle_final.aleo;
+program puzzle_raffle_052224.aleo;
 
 struct PrivateKey:
     pk_pt1 as u128;
@@ -61,7 +61,7 @@ function add_one_raffle_entry:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_one_raffle_entry r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_one_raffle_entry.future;
+    output r1 as puzzle_raffle_052224.aleo/add_one_raffle_entry.future;
 
 finalize add_one_raffle_entry:
     input r0 as address.public;
@@ -76,7 +76,7 @@ function add_two_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_two_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_two_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_two_raffle_entries.future;
 
 finalize add_two_raffle_entries:
     input r0 as address.public;
@@ -93,7 +93,7 @@ function add_three_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_three_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_three_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_three_raffle_entries.future;
 
 finalize add_three_raffle_entries:
     input r0 as address.public;
@@ -112,7 +112,7 @@ function add_four_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_four_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_four_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_four_raffle_entries.future;
 
 finalize add_four_raffle_entries:
     input r0 as address.public;
@@ -133,7 +133,7 @@ function add_five_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_five_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_five_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_five_raffle_entries.future;
 
 finalize add_five_raffle_entries:
     input r0 as address.public;
@@ -156,7 +156,7 @@ function add_six_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_six_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_six_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_six_raffle_entries.future;
 
 finalize add_six_raffle_entries:
     input r0 as address.public;
@@ -181,7 +181,7 @@ function add_seven_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_seven_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_seven_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_seven_raffle_entries.future;
 
 finalize add_seven_raffle_entries:
     input r0 as address.public;
@@ -208,7 +208,7 @@ function add_eight_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_eight_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_eight_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_eight_raffle_entries.future;
 
 finalize add_eight_raffle_entries:
     input r0 as address.public;
@@ -237,7 +237,7 @@ function add_nine_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_nine_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_nine_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_nine_raffle_entries.future;
 
 finalize add_nine_raffle_entries:
     input r0 as address.public;
@@ -268,7 +268,7 @@ function add_ten_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_ten_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_ten_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_ten_raffle_entries.future;
 
 finalize add_ten_raffle_entries:
     input r0 as address.public;
@@ -301,7 +301,7 @@ function add_eleven_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_eleven_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_eleven_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_eleven_raffle_entries.future;
 
 finalize add_eleven_raffle_entries:
     input r0 as address.public;
@@ -336,7 +336,7 @@ function add_twelve_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_twelve_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_twelve_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_twelve_raffle_entries.future;
 
 finalize add_twelve_raffle_entries:
     input r0 as address.public;
@@ -373,7 +373,7 @@ function add_thirteen_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_thirteen_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_thirteen_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_thirteen_raffle_entries.future;
 
 finalize add_thirteen_raffle_entries:
     input r0 as address.public;
@@ -412,7 +412,7 @@ function add_fourteen_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_fourteen_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_fourteen_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_fourteen_raffle_entries.future;
 
 finalize add_fourteen_raffle_entries:
     input r0 as address.public;
@@ -453,7 +453,7 @@ function add_fifteen_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_fifteen_raffle_entries r0 into r1;
-    output r1 as puzzle_single_draw_raffle_final.aleo/add_fifteen_raffle_entries.future;
+    output r1 as puzzle_raffle_052224.aleo/add_fifteen_raffle_entries.future;
 
 finalize add_fifteen_raffle_entries:
     input r0 as address.public;
@@ -495,7 +495,7 @@ function draw_winner:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async draw_winner into r0;
-    output r0 as puzzle_single_draw_raffle_final.aleo/draw_winner.future;
+    output r0 as puzzle_raffle_052224.aleo/draw_winner.future;
 
 finalize draw_winner:
     get total_entries[0u32] into r0;
@@ -521,7 +521,7 @@ function send_prize_to_winner:
     async send_prize_to_winner r0 into r4;
     output r2 as Prize.record;
     output r3 as AuditPrizeToWinner.record;
-    output r4 as puzzle_single_draw_raffle_final.aleo/send_prize_to_winner.future;
+    output r4 as puzzle_raffle_052224.aleo/send_prize_to_winner.future;
 
 finalize send_prize_to_winner:
     input r0 as address.public;

--- a/puzzle_raffle/build/main.aleo
+++ b/puzzle_raffle/build/main.aleo
@@ -43,6 +43,26 @@ mapping winner_count:
 	key as u32.public;
 	value as u32.public;
 
+
+mapping winner_idxs:
+	key as u32.public;
+	value as u64.public;
+
+
+mapping winner_one:
+	key as u32.public;
+	value as address.public;
+
+
+mapping winner_two:
+	key as u32.public;
+	value as address.public;
+
+
+mapping winner_three:
+	key as u32.public;
+	value as address.public;
+
 function mint_prize:
     input r0 as u128.private;
     input r1 as u128.private;
@@ -501,14 +521,25 @@ finalize draw_winner:
     get total_entries[0u64] into r0;
     rand.chacha into r1 as u64;
     rem r1 r0 into r2;
-    get entries[r2] into r3;
-    get.or_use winner_count[0u32] 0u32 into r4;
-    get.or_use has_won[r3] false into r5;
-    not r5 into r6;
-    set true into has_won[r3];
-    set r3 into winner[r4];
-    add r4 1u32 into r7;
-    set r7 into winner_count[0u32];
+    set r2 into winner_idxs[0u32];
+    rand.chacha into r3 as u64;
+    rem r3 r0 into r4;
+    set r4 into winner_idxs[1u32];
+    rand.chacha into r5 as u64;
+    rem r5 r0 into r6;
+    set r6 into winner_idxs[2u32];
+    get winner_idxs[0u32] into r7;
+    get winner_idxs[1u32] into r8;
+    get winner_idxs[2u32] into r9;
+    get entries[r7] into r10;
+    get entries[r8] into r11;
+    get entries[r9] into r12;
+    assert.neq r10 r11;
+    assert.neq r11 r12;
+    assert.neq r10 r12;
+    set r10 into winner_one[0u32];
+    set r11 into winner_two[0u32];
+    set r12 into winner_three[0u32];
 
 
 function send_prize_to_winner:

--- a/puzzle_raffle/build/main.aleo
+++ b/puzzle_raffle/build/main.aleo
@@ -1,4 +1,4 @@
-program puzzle_raffle_050124.aleo;
+program puzzle_single_draw_raffle_final.aleo;
 
 struct PrivateKey:
     pk_pt1 as u128;
@@ -20,13 +20,13 @@ record AuditPrizeToWinner:
 
 
 mapping entries:
-	key as u64.public;
+	key as u32.public;
 	value as address.public;
 
 
 mapping total_entries:
-	key as u64.public;
-	value as u64.public;
+	key as u32.public;
+	value as u32.public;
 
 
 mapping winner:
@@ -42,26 +42,6 @@ mapping has_won:
 mapping winner_count:
 	key as u32.public;
 	value as u32.public;
-
-
-mapping winner_idxs:
-	key as u32.public;
-	value as u64.public;
-
-
-mapping winner_one:
-	key as u32.public;
-	value as address.public;
-
-
-mapping winner_two:
-	key as u32.public;
-	value as address.public;
-
-
-mapping winner_three:
-	key as u32.public;
-	value as address.public;
 
 function mint_prize:
     input r0 as u128.private;
@@ -81,14 +61,14 @@ function add_one_raffle_entry:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_one_raffle_entry r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_one_raffle_entry.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_one_raffle_entry.future;
 
 finalize add_one_raffle_entry:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
-    set r2 into total_entries[0u64];
+    add r1 1u32 into r2;
+    set r2 into total_entries[0u32];
 
 
 function add_two_raffle_entries:
@@ -96,16 +76,16 @@ function add_two_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_two_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_two_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_two_raffle_entries.future;
 
 finalize add_two_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
-    set r3 into total_entries[0u64];
+    add r1 2u32 into r3;
+    set r3 into total_entries[0u32];
 
 
 function add_three_raffle_entries:
@@ -113,18 +93,18 @@ function add_three_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_three_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_three_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_three_raffle_entries.future;
 
 finalize add_three_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
-    set r4 into total_entries[0u64];
+    add r1 3u32 into r4;
+    set r4 into total_entries[0u32];
 
 
 function add_four_raffle_entries:
@@ -132,20 +112,20 @@ function add_four_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_four_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_four_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_four_raffle_entries.future;
 
 finalize add_four_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
-    set r5 into total_entries[0u64];
+    add r1 4u32 into r5;
+    set r5 into total_entries[0u32];
 
 
 function add_five_raffle_entries:
@@ -153,22 +133,22 @@ function add_five_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_five_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_five_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_five_raffle_entries.future;
 
 finalize add_five_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
-    set r6 into total_entries[0u64];
+    add r1 5u32 into r6;
+    set r6 into total_entries[0u32];
 
 
 function add_six_raffle_entries:
@@ -176,24 +156,24 @@ function add_six_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_six_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_six_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_six_raffle_entries.future;
 
 finalize add_six_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
-    set r7 into total_entries[0u64];
+    add r1 6u32 into r7;
+    set r7 into total_entries[0u32];
 
 
 function add_seven_raffle_entries:
@@ -201,26 +181,26 @@ function add_seven_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_seven_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_seven_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_seven_raffle_entries.future;
 
 finalize add_seven_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
+    add r1 6u32 into r7;
     set r0 into entries[r7];
-    add r1 7u64 into r8;
-    set r8 into total_entries[0u64];
+    add r1 7u32 into r8;
+    set r8 into total_entries[0u32];
 
 
 function add_eight_raffle_entries:
@@ -228,28 +208,28 @@ function add_eight_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_eight_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_eight_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_eight_raffle_entries.future;
 
 finalize add_eight_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
+    add r1 6u32 into r7;
     set r0 into entries[r7];
-    add r1 7u64 into r8;
+    add r1 7u32 into r8;
     set r0 into entries[r8];
-    add r1 8u64 into r9;
-    set r9 into total_entries[0u64];
+    add r1 8u32 into r9;
+    set r9 into total_entries[0u32];
 
 
 function add_nine_raffle_entries:
@@ -257,30 +237,30 @@ function add_nine_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_nine_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_nine_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_nine_raffle_entries.future;
 
 finalize add_nine_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
+    add r1 6u32 into r7;
     set r0 into entries[r7];
-    add r1 7u64 into r8;
+    add r1 7u32 into r8;
     set r0 into entries[r8];
-    add r1 8u64 into r9;
+    add r1 8u32 into r9;
     set r0 into entries[r9];
-    add r1 9u64 into r10;
-    set r10 into total_entries[0u64];
+    add r1 9u32 into r10;
+    set r10 into total_entries[0u32];
 
 
 function add_ten_raffle_entries:
@@ -288,32 +268,32 @@ function add_ten_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_ten_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_ten_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_ten_raffle_entries.future;
 
 finalize add_ten_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
+    add r1 6u32 into r7;
     set r0 into entries[r7];
-    add r1 7u64 into r8;
+    add r1 7u32 into r8;
     set r0 into entries[r8];
-    add r1 8u64 into r9;
+    add r1 8u32 into r9;
     set r0 into entries[r9];
-    add r1 9u64 into r10;
+    add r1 9u32 into r10;
     set r0 into entries[r10];
-    add r1 10u64 into r11;
-    set r11 into total_entries[0u64];
+    add r1 10u32 into r11;
+    set r11 into total_entries[0u32];
 
 
 function add_eleven_raffle_entries:
@@ -321,34 +301,34 @@ function add_eleven_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_eleven_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_eleven_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_eleven_raffle_entries.future;
 
 finalize add_eleven_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
+    add r1 6u32 into r7;
     set r0 into entries[r7];
-    add r1 7u64 into r8;
+    add r1 7u32 into r8;
     set r0 into entries[r8];
-    add r1 8u64 into r9;
+    add r1 8u32 into r9;
     set r0 into entries[r9];
-    add r1 9u64 into r10;
+    add r1 9u32 into r10;
     set r0 into entries[r10];
-    add r1 10u64 into r11;
+    add r1 10u32 into r11;
     set r0 into entries[r11];
-    add r1 11u64 into r12;
-    set r12 into total_entries[0u64];
+    add r1 11u32 into r12;
+    set r12 into total_entries[0u32];
 
 
 function add_twelve_raffle_entries:
@@ -356,36 +336,36 @@ function add_twelve_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_twelve_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_twelve_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_twelve_raffle_entries.future;
 
 finalize add_twelve_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
+    add r1 6u32 into r7;
     set r0 into entries[r7];
-    add r1 7u64 into r8;
+    add r1 7u32 into r8;
     set r0 into entries[r8];
-    add r1 8u64 into r9;
+    add r1 8u32 into r9;
     set r0 into entries[r9];
-    add r1 9u64 into r10;
+    add r1 9u32 into r10;
     set r0 into entries[r10];
-    add r1 10u64 into r11;
+    add r1 10u32 into r11;
     set r0 into entries[r11];
-    add r1 11u64 into r12;
+    add r1 11u32 into r12;
     set r0 into entries[r12];
-    add r1 12u64 into r13;
-    set r13 into total_entries[0u64];
+    add r1 12u32 into r13;
+    set r13 into total_entries[0u32];
 
 
 function add_thirteen_raffle_entries:
@@ -393,38 +373,38 @@ function add_thirteen_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_thirteen_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_thirteen_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_thirteen_raffle_entries.future;
 
 finalize add_thirteen_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
+    add r1 6u32 into r7;
     set r0 into entries[r7];
-    add r1 7u64 into r8;
+    add r1 7u32 into r8;
     set r0 into entries[r8];
-    add r1 8u64 into r9;
+    add r1 8u32 into r9;
     set r0 into entries[r9];
-    add r1 9u64 into r10;
+    add r1 9u32 into r10;
     set r0 into entries[r10];
-    add r1 10u64 into r11;
+    add r1 10u32 into r11;
     set r0 into entries[r11];
-    add r1 11u64 into r12;
+    add r1 11u32 into r12;
     set r0 into entries[r12];
-    add r1 12u64 into r13;
+    add r1 12u32 into r13;
     set r0 into entries[r13];
-    add r1 13u64 into r14;
-    set r14 into total_entries[0u64];
+    add r1 13u32 into r14;
+    set r14 into total_entries[0u32];
 
 
 function add_fourteen_raffle_entries:
@@ -432,40 +412,40 @@ function add_fourteen_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_fourteen_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_fourteen_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_fourteen_raffle_entries.future;
 
 finalize add_fourteen_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
+    add r1 6u32 into r7;
     set r0 into entries[r7];
-    add r1 7u64 into r8;
+    add r1 7u32 into r8;
     set r0 into entries[r8];
-    add r1 8u64 into r9;
+    add r1 8u32 into r9;
     set r0 into entries[r9];
-    add r1 9u64 into r10;
+    add r1 9u32 into r10;
     set r0 into entries[r10];
-    add r1 10u64 into r11;
+    add r1 10u32 into r11;
     set r0 into entries[r11];
-    add r1 11u64 into r12;
+    add r1 11u32 into r12;
     set r0 into entries[r12];
-    add r1 12u64 into r13;
+    add r1 12u32 into r13;
     set r0 into entries[r13];
-    add r1 13u64 into r14;
+    add r1 13u32 into r14;
     set r0 into entries[r14];
-    add r1 14u64 into r15;
-    set r15 into total_entries[0u64];
+    add r1 14u32 into r15;
+    set r15 into total_entries[0u32];
 
 
 function add_fifteen_raffle_entries:
@@ -473,93 +453,62 @@ function add_fifteen_raffle_entries:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async add_fifteen_raffle_entries r0 into r1;
-    output r1 as puzzle_raffle_050124.aleo/add_fifteen_raffle_entries.future;
+    output r1 as puzzle_single_draw_raffle_final.aleo/add_fifteen_raffle_entries.future;
 
 finalize add_fifteen_raffle_entries:
     input r0 as address.public;
-    get.or_use total_entries[0u64] 0u64 into r1;
+    get.or_use total_entries[0u32] 0u32 into r1;
     set r0 into entries[r1];
-    add r1 1u64 into r2;
+    add r1 1u32 into r2;
     set r0 into entries[r2];
-    add r1 2u64 into r3;
+    add r1 2u32 into r3;
     set r0 into entries[r3];
-    add r1 3u64 into r4;
+    add r1 3u32 into r4;
     set r0 into entries[r4];
-    add r1 4u64 into r5;
+    add r1 4u32 into r5;
     set r0 into entries[r5];
-    add r1 5u64 into r6;
+    add r1 5u32 into r6;
     set r0 into entries[r6];
-    add r1 6u64 into r7;
+    add r1 6u32 into r7;
     set r0 into entries[r7];
-    add r1 7u64 into r8;
+    add r1 7u32 into r8;
     set r0 into entries[r8];
-    add r1 8u64 into r9;
+    add r1 8u32 into r9;
     set r0 into entries[r9];
-    add r1 9u64 into r10;
+    add r1 9u32 into r10;
     set r0 into entries[r10];
-    add r1 10u64 into r11;
+    add r1 10u32 into r11;
     set r0 into entries[r11];
-    add r1 11u64 into r12;
+    add r1 11u32 into r12;
     set r0 into entries[r12];
-    add r1 12u64 into r13;
+    add r1 12u32 into r13;
     set r0 into entries[r13];
-    add r1 13u64 into r14;
+    add r1 13u32 into r14;
     set r0 into entries[r14];
-    add r1 14u64 into r15;
+    add r1 14u32 into r15;
     set r0 into entries[r15];
-    add r1 15u64 into r16;
-    set r16 into total_entries[0u64];
+    add r1 15u32 into r16;
+    set r16 into total_entries[0u32];
 
 
 function draw_winner:
     assert.eq self.caller self.signer;
     assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
     async draw_winner into r0;
-    output r0 as puzzle_raffle_050124.aleo/draw_winner.future;
+    output r0 as puzzle_single_draw_raffle_final.aleo/draw_winner.future;
 
 finalize draw_winner:
-    get total_entries[0u64] into r0;
-    rand.chacha into r1 as u64;
+    get total_entries[0u32] into r0;
+    rand.chacha into r1 as u32;
     rem r1 r0 into r2;
     get entries[r2] into r3;
-    get.or_use winner_count[0u32] 0u32 into r4;
-    get.or_use has_won[r3] false into r5;
-    not r5 into r6;
+    get.or_use has_won[r3] false into r4;
+    assert.eq r4 false;
+    get.or_use winner_count[0u32] 0u32 into r5;
     set true into has_won[r3];
-    add r4 1u32 into r7;
-    set r7 into winner_count[0u32];
-    set r3 into winner[r4];
-
-
-function draw_three_winners:
-    assert.eq self.caller self.signer;
-    assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
-    async draw_three_winners into r0;
-    output r0 as puzzle_raffle_050124.aleo/draw_three_winners.future;
-
-finalize draw_three_winners:
-    get total_entries[0u64] into r0;
-    rand.chacha into r1 as u64;
-    rem r1 r0 into r2;
-    set r2 into winner_idxs[0u32];
-    rand.chacha into r3 as u64;
-    rem r3 r0 into r4;
-    set r4 into winner_idxs[1u32];
-    rand.chacha into r5 as u64;
-    rem r5 r0 into r6;
-    set r6 into winner_idxs[2u32];
-    get winner_idxs[0u32] into r7;
-    get winner_idxs[1u32] into r8;
-    get winner_idxs[2u32] into r9;
-    get entries[r7] into r10;
-    get entries[r8] into r11;
-    get entries[r9] into r12;
-    assert.neq r10 r11;
-    assert.neq r11 r12;
-    assert.neq r10 r12;
-    set r10 into winner_one[0u32];
-    set r11 into winner_two[0u32];
-    set r12 into winner_three[0u32];
+    add r5 1u32 into r6;
+    set r6 into winner_count[0u32];
+    set r3 into winner[r5];
 
 
 function send_prize_to_winner:
@@ -572,41 +521,9 @@ function send_prize_to_winner:
     async send_prize_to_winner r0 into r4;
     output r2 as Prize.record;
     output r3 as AuditPrizeToWinner.record;
-    output r4 as puzzle_raffle_050124.aleo/send_prize_to_winner.future;
+    output r4 as puzzle_single_draw_raffle_final.aleo/send_prize_to_winner.future;
 
 finalize send_prize_to_winner:
     input r0 as address.public;
     get.or_use has_won[r0] false into r1;
     assert.eq r1 true;
-
-
-function send_three_prizes_to_winners:
-    input r0 as address.public;
-    input r1 as address.public;
-    input r2 as address.public;
-    input r3 as u32.public;
-    input r4 as Prize.record;
-    input r5 as Prize.record;
-    input r6 as Prize.record;
-    assert.eq self.caller self.signer;
-    assert.eq self.caller aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
-    cast r0 r4.private_key into r7 as Prize.record;
-    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r0 r4.private_key into r8 as AuditPrizeToWinner.record;
-    cast r1 r5.private_key into r9 as Prize.record;
-    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r1 r5.private_key into r10 as AuditPrizeToWinner.record;
-    cast r2 r6.private_key into r11 as Prize.record;
-    cast aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw r2 r6.private_key into r12 as AuditPrizeToWinner.record;
-    async send_three_prizes_to_winners r0 r1 r2 r3 into r13;
-    output r13 as puzzle_raffle_050124.aleo/send_three_prizes_to_winners.future;
-
-finalize send_three_prizes_to_winners:
-    input r0 as address.public;
-    input r1 as address.public;
-    input r2 as address.public;
-    input r3 as u32.public;
-    get winner_one[r3] into r4;
-    assert.eq r4 r0;
-    get winner_two[r3] into r5;
-    assert.eq r5 r1;
-    get winner_three[r3] into r6;
-    assert.eq r6 r2;

--- a/puzzle_raffle/build/program.json
+++ b/puzzle_raffle/build/program.json
@@ -1,5 +1,5 @@
 {
-    "program": "puzzle_single_draw_raffle_final.aleo",
+    "program": "puzzle_raffle_052224.aleo",
     "version": "0.0.0",
     "description": "",
     "license": "MIT"

--- a/puzzle_raffle/build/program.json
+++ b/puzzle_raffle/build/program.json
@@ -1,5 +1,5 @@
 {
-    "program": "puzzle_raffle_050124.aleo",
+    "program": "puzzle_single_draw_raffle_final.aleo",
     "version": "0.0.0",
     "description": "",
     "license": "MIT"

--- a/puzzle_raffle/program.json
+++ b/puzzle_raffle/program.json
@@ -1,5 +1,5 @@
 {
-    "program": "puzzle_single_draw_raffle_final.aleo",
+    "program": "puzzle_raffle_052224.aleo",
     "version": "0.0.0",
     "description": "",
     "license": "MIT"

--- a/puzzle_raffle/program.json
+++ b/puzzle_raffle/program.json
@@ -1,5 +1,5 @@
 {
-    "program": "puzzle_raffle_050124.aleo",
+    "program": "puzzle_single_draw_raffle_final.aleo",
     "version": "0.0.0",
     "description": "",
     "license": "MIT"

--- a/puzzle_raffle/src/main.leo
+++ b/puzzle_raffle/src/main.leo
@@ -5,7 +5,7 @@ program puzzle_raffle_050124.aleo {
     // used for storing of total number of values in entries mapping
     //   i.e. 0 -> 1, 0 -> 2
     mapping total_entries: u64 => u64;
-    // 0u32 -> aleo1...lka
+    // 1u32 -> aleo1...lka
     mapping winner: u32 => address;
     // mapping to store winner aleo1... => true (if addr has won)
     mapping has_won: address => bool;
@@ -396,10 +396,10 @@ program puzzle_raffle_050124.aleo {
         if (has_addr_won.not()) {
             // set addr to true {aleo1...: true}
             Mapping::set(has_won, winner_address, true);
-            // set winner { 0u32: aleo1...} ...
-            Mapping::set(winner, current_winner_count, winner_address);
             // increment winner count {0u32: 1u32} and so on
             Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
+            // set winner { 1u32: aleo1...} ...
+            Mapping::set(winner, current_winner_count, winner_address);
         }
     }
 
@@ -440,7 +440,7 @@ program puzzle_raffle_050124.aleo {
 
     }
 
-    transition send_prize_to_winner (public winner_addr: address, public prize: Prize) -> (Prize, AuditPrizeToWinner) {
+    transition send_prize_to_winner (public winner_addr: address, public prize: Prize, public winner_idx: u32) -> (Prize, AuditPrizeToWinner) {
         let operator: address = aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
         assert_eq(self.caller, self.signer);
         assert_eq(self.caller, operator);
@@ -457,18 +457,15 @@ program puzzle_raffle_050124.aleo {
             private_key: prize.private_key,
         };
 
-        return (prize_to_winner, audit_prize_to_winner);
-        //  then finalize (winner_addr);
+        return (prize_to_winner, audit_prize_to_winner) then finalize (winner_addr, winner_idx);
     }
 
-    // finalize send_prize_to_winner (public winner_addr: address) {
-    //     // get the current winner idx
-    //     // let current_winner_count_idx: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);
-    //     // get the current winner via the index (if draw_winner is called multiple times)
-    //     // let winner_addr_from_mapping: address = Mapping::get(winner, current_winner_count_idx);
-    //     // assert that this function is called with the winner_addr
-    //     // assert_eq(winner_addr, winner_addr_from_mapping);
-    // }
+    finalize send_prize_to_winner (public winner_addr: address, public winner_idx: u32) {
+        // get the current winner via the index (if draw_winner is called multiple times)
+        let winner_addr_from_mapping: address = Mapping::get(winner, winner_idx);
+        // assert that this function is called with the winner_addr
+        assert_eq(winner_addr, winner_addr_from_mapping);
+    }
 
 
     transition send_three_prizes_to_winners(
@@ -530,7 +527,7 @@ program puzzle_raffle_050124.aleo {
         public winner_idx: u32,
     )
     {
-        // assert that the prizer are being sent to the official winners
+        // assert that the prizes are being sent to the official winners
         assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_one);
         assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_two);
         assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_three);

--- a/puzzle_raffle/src/main.leo
+++ b/puzzle_raffle/src/main.leo
@@ -383,8 +383,11 @@ program puzzle_raffle_050124.aleo {
 
         // if the winner has never been selected
         if (Mapping::get_or_use(has_won, winner_address, false)) {
+            // set addr to true {aleo1...: true}
             Mapping::set(has_won, winner_address, true);
+            // set winner { 0u32: aleo1...} ...
             Mapping::set(winner, current_winner_count, winner_address);
+            // increment winner count {0u32: 1u32} and so on
             Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
         }
     }

--- a/puzzle_raffle/src/main.leo
+++ b/puzzle_raffle/src/main.leo
@@ -13,6 +13,13 @@ program puzzle_raffle_050124.aleo {
     // winner_count
     mapping winner_count: u32 => u32;
 
+    // winner_indexes
+    mapping winner_idxs: u32 => u64;
+
+    mapping winner_one: u32 => address;
+    mapping winner_two: u32 => address;
+    mapping winner_three: u32 => address;
+
     struct PrivateKey {
         pk_pt1: u128,
         pk_pt2: u128
@@ -368,31 +375,56 @@ program puzzle_raffle_050124.aleo {
         return then finalize;
     }
 
-
     finalize draw_winner () {
-        // get total entries
         let num_entries: u64 = Mapping::get(total_entries, 0u64);
-        // grab random number
-        let random_number: u64 = ChaCha::rand_u64();
-        // select winning index
-        let winner_index: u64 = random_number % num_entries;
-        // get address at winning index
-        let winner_address: address = Mapping::get(entries, winner_index);
-        // get the winner_count
-        let current_winner_count: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);
-        // true if addr has already won, false if not
-        let has_addr_won: bool = Mapping::get_or_use(has_won, winner_address, false);
-
-        // if the winner has never been selected
-        if (has_addr_won.not()) {
-            // set addr to true {aleo1...: true}
-            Mapping::set(has_won, winner_address, true);
-            // set winner { 0u32: aleo1...} ...
-            Mapping::set(winner, current_winner_count, winner_address);
-            // increment winner count {0u32: 1u32} and so on
-            Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
+        for i: u32 in 0u32..3u32 {
+            let random_number: u64 = ChaCha::rand_u64();
+            let winner_index: u64 = random_number % num_entries;
+            Mapping::set(winner_idxs, i, winner_index);
         }
+        let winner_idx_one: u64 = Mapping::get(winner_idxs, 0u32);
+        let winner_idx_two: u64 = Mapping::get(winner_idxs, 1u32);
+        let winner_idx_three: u64 = Mapping::get(winner_idxs, 2u32);
+
+        let winner_address_one: address = Mapping::get(entries, winner_idx_one);
+        let winner_address_two: address = Mapping::get(entries, winner_idx_two);
+        let winner_address_three: address = Mapping::get(entries, winner_idx_three);
+
+        assert_neq(winner_address_one, winner_address_two);
+        assert_neq(winner_address_two, winner_address_three);
+        assert_neq(winner_address_one, winner_address_three);
+
+        Mapping::set(winner_one, 0u32, winner_address_one);
+        Mapping::set(winner_two, 0u32, winner_address_two);
+        Mapping::set(winner_three, 0u32, winner_address_three);
+
     }
+
+
+    // finalize draw_winner () {
+    //     // get total entries
+    //     let num_entries: u64 = Mapping::get(total_entries, 0u64);
+    //     // grab random number
+    //     let random_number: u64 = ChaCha::rand_u64();
+    //     // select winning index
+    //     let winner_index: u64 = random_number % num_entries;
+    //     // get address at winning index
+    //     let winner_address: address = Mapping::get(entries, winner_index);
+    //     // get the winner_count
+    //     let current_winner_count: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);
+    //     // true if addr has already won, false if not
+    //     let has_addr_won: bool = Mapping::get_or_use(has_won, winner_address, false);
+
+    //     // if the winner has never been selected
+    //     if (has_addr_won.not()) {
+    //         // set addr to true {aleo1...: true}
+    //         Mapping::set(has_won, winner_address, true);
+    //         // set winner { 0u32: aleo1...} ...
+    //         Mapping::set(winner, current_winner_count, winner_address);
+    //         // increment winner count {0u32: 1u32} and so on
+    //         Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
+    //     }
+    // }
 
     transition send_prize_to_winner (public winner_addr: address, public prize: Prize) -> (Prize, AuditPrizeToWinner) {
         let operator: address = aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;

--- a/puzzle_raffle/src/main.leo
+++ b/puzzle_raffle/src/main.leo
@@ -440,7 +440,7 @@ program puzzle_raffle_050124.aleo {
 
     }
 
-    transition send_prize_to_winner (public winner_addr: address, public prize: Prize, public winner_idx: u32) -> (Prize, AuditPrizeToWinner) {
+    transition send_prize_to_winner (public winner_addr: address, public prize: Prize) -> (Prize, AuditPrizeToWinner) {
         let operator: address = aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
         assert_eq(self.caller, self.signer);
         assert_eq(self.caller, operator);
@@ -457,14 +457,12 @@ program puzzle_raffle_050124.aleo {
             private_key: prize.private_key,
         };
 
-        return (prize_to_winner, audit_prize_to_winner) then finalize (winner_addr, winner_idx);
+        return (prize_to_winner, audit_prize_to_winner) then finalize (winner_addr);
     }
 
-    finalize send_prize_to_winner (public winner_addr: address, public winner_idx: u32) {
-        // get the current winner via the index (if draw_winner is called multiple times)
-        let winner_addr_from_mapping: address = Mapping::get(winner, winner_idx);
-        // assert that this function is called with the winner_addr
-        assert_eq(winner_addr, winner_addr_from_mapping);
+    finalize send_prize_to_winner (public winner_addr: address) {
+        let has_addr_won: bool = Mapping::get_or_use(has_won, winner_addr, false);
+        assert(has_addr_won);
     }
 
 
@@ -529,8 +527,8 @@ program puzzle_raffle_050124.aleo {
     {
         // assert that the prizes are being sent to the official winners
         assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_one);
-        assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_two);
-        assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_three);
+        assert_eq(Mapping::get(winner_two, winner_idx), winner_addr_two);
+        assert_eq(Mapping::get(winner_three, winner_idx), winner_addr_three);
 
     }
 

--- a/puzzle_raffle/src/main.leo
+++ b/puzzle_raffle/src/main.leo
@@ -7,6 +7,8 @@ program puzzle_raffle_v009.aleo {
     mapping total_entries: u64 => u64;
     // 0u32 -> aleo1...lka
     mapping winner: u32 => address;
+    // mapping to store winner aleo1... => true (if addr has won)
+    mapping has_won: address => bool;
 
     // winner_count
     mapping winner_count: u32 => u32;
@@ -378,11 +380,13 @@ program puzzle_raffle_v009.aleo {
         let winner_address: address = Mapping::get(entries, winner_index);
         // get the winner_count
         let current_winner_count: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);
-        // set the winner address
-        Mapping::set(winner, current_winner_count, winner_address);
-        // increment the winner count
-        //todo: update this to fix this mapping being 1 ahead of other mapping
-        Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
+
+        // if the winner has never been selected
+        if (Mapping::get_or_use(has_won, winner_address, false)) {
+            Mapping::set(has_won, winner_address, true);
+            Mapping::set(winner, current_winner_count, winner_address);
+            Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
+        }
     }
 
     transition send_prize_to_winner (public winner_addr: address, public prize: Prize) -> (Prize, AuditPrizeToWinner) {

--- a/puzzle_raffle/src/main.leo
+++ b/puzzle_raffle/src/main.leo
@@ -1,27 +1,16 @@
-program puzzle_raffle_050124.aleo {
+program puzzle_single_draw_raffle_final.aleo {
     // used for storing the raffle entries (multiple entries per address)
     //   i.e. 0 -> aleo1...asdf, 1 -> aleo1...ghjk
-    mapping entries: u64 => address;
+    mapping entries: u32 => address;
     // used for storing of total number of values in entries mapping
     //   i.e. 0 -> 1, 0 -> 2
-    mapping total_entries: u64 => u64;
+    mapping total_entries: u32 => u32;
     // 1u32 -> aleo1...lka
     mapping winner: u32 => address;
     // mapping to store winner aleo1... => true (if addr has won)
     mapping has_won: address => bool;
-
-    // winner_count
+    // total number of winners
     mapping winner_count: u32 => u32;
-
-    // winner_indexes
-    mapping winner_idxs: u32 => u64;
-
-    // mapping to store winner one
-    mapping winner_one: u32 => address;
-    // mapping to store winner two
-    mapping winner_two: u32 => address;
-    // mapping to store winner three
-    mapping winner_three: u32 => address;
 
     struct PrivateKey {
         pk_pt1: u128,
@@ -90,12 +79,12 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_one_raffle_entry (public participant: address) {
-        // get current raffle count, if first entry, choose default of 0u64
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        // get current raffle count, if first entry, choose default of 0u32
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         // add address to entry mapping
         Mapping::set(entries, current_raffle_count, participant);
         // increment raffle count by 1
-        Mapping::set(total_entries, 0u64, current_raffle_count + 1u64);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 1u32);
     }
 
     transition add_two_raffle_entries (public participant: address ) {
@@ -105,10 +94,10 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_two_raffle_entries (public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 2u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 2u32);
     }
 
     transition add_three_raffle_entries (public participant: address) {
@@ -118,11 +107,11 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_three_raffle_entries (public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 3u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 3u32);
     }
 
     transition add_four_raffle_entries(public participant: address) {
@@ -132,12 +121,12 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_four_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 4u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 4u32);
     }
 
     transition add_five_raffle_entries(public participant: address,) {
@@ -147,13 +136,13 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_five_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 5u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 5u32);
     }
 
     transition add_six_raffle_entries(public participant: address) {
@@ -163,14 +152,14 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_six_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 6u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 6u32);
     }
 
     transition add_seven_raffle_entries(public participant: address) {
@@ -180,15 +169,15 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_seven_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(entries, current_raffle_count + 6u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 7u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(entries, current_raffle_count + 6u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 7u32);
     }
 
     transition add_eight_raffle_entries(public participant: address) {
@@ -198,16 +187,16 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_eight_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(entries, current_raffle_count + 6u64, participant);
-        Mapping::set(entries, current_raffle_count + 7u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 8u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(entries, current_raffle_count + 6u32, participant);
+        Mapping::set(entries, current_raffle_count + 7u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 8u32);
     }
 
     transition add_nine_raffle_entries(public participant: address) {
@@ -217,17 +206,17 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_nine_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(entries, current_raffle_count + 6u64, participant);
-        Mapping::set(entries, current_raffle_count + 7u64, participant);
-        Mapping::set(entries, current_raffle_count + 8u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 9u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(entries, current_raffle_count + 6u32, participant);
+        Mapping::set(entries, current_raffle_count + 7u32, participant);
+        Mapping::set(entries, current_raffle_count + 8u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 9u32);
     }
 
     transition add_ten_raffle_entries(public participant: address) {
@@ -237,18 +226,18 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_ten_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(entries, current_raffle_count + 6u64, participant);
-        Mapping::set(entries, current_raffle_count + 7u64, participant);
-        Mapping::set(entries, current_raffle_count + 8u64, participant);
-        Mapping::set(entries, current_raffle_count + 9u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 10u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(entries, current_raffle_count + 6u32, participant);
+        Mapping::set(entries, current_raffle_count + 7u32, participant);
+        Mapping::set(entries, current_raffle_count + 8u32, participant);
+        Mapping::set(entries, current_raffle_count + 9u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 10u32);
     }
 
     transition add_eleven_raffle_entries(public participant: address) {
@@ -258,19 +247,19 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_eleven_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(entries, current_raffle_count + 6u64, participant);
-        Mapping::set(entries, current_raffle_count + 7u64, participant);
-        Mapping::set(entries, current_raffle_count + 8u64, participant);
-        Mapping::set(entries, current_raffle_count + 9u64, participant);
-        Mapping::set(entries, current_raffle_count + 10u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 11u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(entries, current_raffle_count + 6u32, participant);
+        Mapping::set(entries, current_raffle_count + 7u32, participant);
+        Mapping::set(entries, current_raffle_count + 8u32, participant);
+        Mapping::set(entries, current_raffle_count + 9u32, participant);
+        Mapping::set(entries, current_raffle_count + 10u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 11u32);
     }
 
     transition add_twelve_raffle_entries(public participant: address) {
@@ -280,20 +269,20 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_twelve_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(entries, current_raffle_count + 6u64, participant);
-        Mapping::set(entries, current_raffle_count + 7u64, participant);
-        Mapping::set(entries, current_raffle_count + 8u64, participant);
-        Mapping::set(entries, current_raffle_count + 9u64, participant);
-        Mapping::set(entries, current_raffle_count + 10u64, participant);
-        Mapping::set(entries, current_raffle_count + 11u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 12u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(entries, current_raffle_count + 6u32, participant);
+        Mapping::set(entries, current_raffle_count + 7u32, participant);
+        Mapping::set(entries, current_raffle_count + 8u32, participant);
+        Mapping::set(entries, current_raffle_count + 9u32, participant);
+        Mapping::set(entries, current_raffle_count + 10u32, participant);
+        Mapping::set(entries, current_raffle_count + 11u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 12u32);
     }
 
     transition add_thirteen_raffle_entries(public participant: address) {
@@ -303,21 +292,21 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_thirteen_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(entries, current_raffle_count + 6u64, participant);
-        Mapping::set(entries, current_raffle_count + 7u64, participant);
-        Mapping::set(entries, current_raffle_count + 8u64, participant);
-        Mapping::set(entries, current_raffle_count + 9u64, participant);
-        Mapping::set(entries, current_raffle_count + 10u64, participant);
-        Mapping::set(entries, current_raffle_count + 11u64, participant);
-        Mapping::set(entries, current_raffle_count + 12u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 13u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(entries, current_raffle_count + 6u32, participant);
+        Mapping::set(entries, current_raffle_count + 7u32, participant);
+        Mapping::set(entries, current_raffle_count + 8u32, participant);
+        Mapping::set(entries, current_raffle_count + 9u32, participant);
+        Mapping::set(entries, current_raffle_count + 10u32, participant);
+        Mapping::set(entries, current_raffle_count + 11u32, participant);
+        Mapping::set(entries, current_raffle_count + 12u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 13u32);
     }
 
     transition add_fourteen_raffle_entries(public participant: address) {
@@ -327,22 +316,22 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_fourteen_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(entries, current_raffle_count + 6u64, participant);
-        Mapping::set(entries, current_raffle_count + 7u64, participant);
-        Mapping::set(entries, current_raffle_count + 8u64, participant);
-        Mapping::set(entries, current_raffle_count + 9u64, participant);
-        Mapping::set(entries, current_raffle_count + 10u64, participant);
-        Mapping::set(entries, current_raffle_count + 11u64, participant);
-        Mapping::set(entries, current_raffle_count + 12u64, participant);
-        Mapping::set(entries, current_raffle_count + 13u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 14u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(entries, current_raffle_count + 6u32, participant);
+        Mapping::set(entries, current_raffle_count + 7u32, participant);
+        Mapping::set(entries, current_raffle_count + 8u32, participant);
+        Mapping::set(entries, current_raffle_count + 9u32, participant);
+        Mapping::set(entries, current_raffle_count + 10u32, participant);
+        Mapping::set(entries, current_raffle_count + 11u32, participant);
+        Mapping::set(entries, current_raffle_count + 12u32, participant);
+        Mapping::set(entries, current_raffle_count + 13u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 14u32);
     }
 
     transition add_fifteen_raffle_entries(public participant: address) {
@@ -352,26 +341,25 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize add_fifteen_raffle_entries(public participant: address) {
-        let current_raffle_count: u64 = Mapping::get_or_use(total_entries, 0u64, 0u64);
+        let current_raffle_count: u32 = Mapping::get_or_use(total_entries, 0u32, 0u32);
         Mapping::set(entries, current_raffle_count, participant);
-        Mapping::set(entries, current_raffle_count + 1u64, participant);
-        Mapping::set(entries, current_raffle_count + 2u64, participant);
-        Mapping::set(entries, current_raffle_count + 3u64, participant);
-        Mapping::set(entries, current_raffle_count + 4u64, participant);
-        Mapping::set(entries, current_raffle_count + 5u64, participant);
-        Mapping::set(entries, current_raffle_count + 6u64, participant);
-        Mapping::set(entries, current_raffle_count + 7u64, participant);
-        Mapping::set(entries, current_raffle_count + 8u64, participant);
-        Mapping::set(entries, current_raffle_count + 9u64, participant);
-        Mapping::set(entries, current_raffle_count + 10u64, participant);
-        Mapping::set(entries, current_raffle_count + 11u64, participant);
-        Mapping::set(entries, current_raffle_count + 12u64, participant);
-        Mapping::set(entries, current_raffle_count + 13u64, participant);
-        Mapping::set(entries, current_raffle_count + 14u64, participant);
-        Mapping::set(total_entries, 0u64, current_raffle_count + 15u64);
+        Mapping::set(entries, current_raffle_count + 1u32, participant);
+        Mapping::set(entries, current_raffle_count + 2u32, participant);
+        Mapping::set(entries, current_raffle_count + 3u32, participant);
+        Mapping::set(entries, current_raffle_count + 4u32, participant);
+        Mapping::set(entries, current_raffle_count + 5u32, participant);
+        Mapping::set(entries, current_raffle_count + 6u32, participant);
+        Mapping::set(entries, current_raffle_count + 7u32, participant);
+        Mapping::set(entries, current_raffle_count + 8u32, participant);
+        Mapping::set(entries, current_raffle_count + 9u32, participant);
+        Mapping::set(entries, current_raffle_count + 10u32, participant);
+        Mapping::set(entries, current_raffle_count + 11u32, participant);
+        Mapping::set(entries, current_raffle_count + 12u32, participant);
+        Mapping::set(entries, current_raffle_count + 13u32, participant);
+        Mapping::set(entries, current_raffle_count + 14u32, participant);
+        Mapping::set(total_entries, 0u32, current_raffle_count + 15u32);
     }
 
-    // todo: allow draw winner to only be called once
     transition draw_winner () {
         assert_eq(self.caller, self.signer);
         assert_eq(self.caller, aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw);
@@ -380,71 +368,33 @@ program puzzle_raffle_050124.aleo {
 
     finalize draw_winner () {
         // get total entries
-        let num_entries: u64 = Mapping::get(total_entries, 0u64);
+        let num_entries: u32 = Mapping::get(total_entries, 0u32);
         // grab random number
-        let random_number: u64 = ChaCha::rand_u64();
+        let random_number: u32 = ChaCha::rand_u32();
         // select winning index
-        let winner_index: u64 = random_number % num_entries;
+        let winner_index: u32 = random_number % num_entries;
         // get address at winning index
         let winner_address: address = Mapping::get(entries, winner_index);
-        // get the winner_count
-        let current_winner_count: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);
         // true if addr has already won, false if not
         let has_addr_won: bool = Mapping::get_or_use(has_won, winner_address, false);
 
-        // if the winner has never been selected
-        if (has_addr_won.not()) {
-            // set addr to true {aleo1...: true}
-            Mapping::set(has_won, winner_address, true);
-            // increment winner count {0u32: 1u32} and so on
-            Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
-            // set winner { 1u32: aleo1...} ...
-            Mapping::set(winner, current_winner_count, winner_address);
-        }
-    }
+        // if the drawn address has already won, fail
+        assert_eq(has_addr_won, false); 
 
-    // fn to draw 3 winners
-    transition draw_three_winners () {
-        assert_eq(self.caller, self.signer);
-        assert_eq(self.caller, aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw);
-        return then finalize;
-    }
-
-    finalize draw_three_winners () {
-        let num_entries: u64 = Mapping::get(total_entries, 0u64);
-        for i: u32 in 0u32..3u32 {
-            let random_number: u64 = ChaCha::rand_u64();
-            let winner_index: u64 = random_number % num_entries;
-            Mapping::set(winner_idxs, i, winner_index);
-        }
-
-        // grah the three random idxs
-        let winner_idx_one: u64 = Mapping::get(winner_idxs, 0u32);
-        let winner_idx_two: u64 = Mapping::get(winner_idxs, 1u32);
-        let winner_idx_three: u64 = Mapping::get(winner_idxs, 2u32);
-
-        // get the addresses at the three random idxs
-        let winner_address_one: address = Mapping::get(entries, winner_idx_one);
-        let winner_address_two: address = Mapping::get(entries, winner_idx_two);
-        let winner_address_three: address = Mapping::get(entries, winner_idx_three);
-
-        // assert that none of the addresses are equivalent
-        assert_neq(winner_address_one, winner_address_two);
-        assert_neq(winner_address_two, winner_address_three);
-        assert_neq(winner_address_one, winner_address_three);
-
-        // set each winner on each mapping
-        Mapping::set(winner_one, 0u32, winner_address_one);
-        Mapping::set(winner_two, 0u32, winner_address_two);
-        Mapping::set(winner_three, 0u32, winner_address_three);
-
+        // get the winner_count
+        let current_winner_count: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);
+        // set addr to true {aleo1...: true}
+        Mapping::set(has_won, winner_address, true);
+        // increment winner count {0u32: 1u32} and so on
+        Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
+        // set winner { 1u32: aleo1...} ...
+        Mapping::set(winner, current_winner_count, winner_address);
     }
 
     transition send_prize_to_winner (public winner_addr: address, public prize: Prize) -> (Prize, AuditPrizeToWinner) {
         let operator: address = aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
         assert_eq(self.caller, self.signer);
         assert_eq(self.caller, operator);
-
 
         let prize_to_winner: Prize = Prize {
             owner: winner_addr,
@@ -463,73 +413,6 @@ program puzzle_raffle_050124.aleo {
     finalize send_prize_to_winner (public winner_addr: address) {
         let has_addr_won: bool = Mapping::get_or_use(has_won, winner_addr, false);
         assert(has_addr_won);
-    }
-
-
-    transition send_three_prizes_to_winners(
-        public winner_addr_one: address,
-        public winner_addr_two: address,
-        public winner_addr_three: address,
-        public winner_idx: u32,
-        public prize_one: Prize,
-        public prize_two: Prize,
-        public prize_three: Prize,
-    )
-    {
-        let operator: address = aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
-        assert_eq(self.caller, self.signer);
-        assert_eq(self.caller, operator);
-
-        let prize_to_winner_one: Prize = Prize {
-            owner: winner_addr_one,
-            private_key: prize_one.private_key,
-        };
-
-        let audit_prize_to_winner_one: AuditPrizeToWinner = AuditPrizeToWinner {
-            owner: operator,
-            winner: winner_addr_one,
-            private_key: prize_one.private_key,
-        };
-
-        let prize_to_winner_two: Prize = Prize {
-            owner: winner_addr_two,
-            private_key: prize_two.private_key,
-        };
-
-        let audit_prize_to_winner_two: AuditPrizeToWinner = AuditPrizeToWinner {
-            owner: operator,
-            winner: winner_addr_two,
-            private_key: prize_two.private_key,
-        };
-
-        let prize_to_winner_three: Prize = Prize {
-            owner: winner_addr_three,
-            private_key: prize_three.private_key,
-        };
-
-        let audit_prize_to_winner_three: AuditPrizeToWinner = AuditPrizeToWinner {
-            owner: operator,
-            winner: winner_addr_three,
-            private_key: prize_three.private_key,
-        };
-
-
-        return then finalize (winner_addr_one, winner_addr_two, winner_addr_three, winner_idx);
-
-    }
-
-    finalize send_three_prizes_to_winners (
-        public winner_addr_one: address,
-        public winner_addr_two: address,
-        public winner_addr_three: address,
-        public winner_idx: u32,
-    )
-    {
-        // assert that the prizes are being sent to the official winners
-        assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_one);
-        assert_eq(Mapping::get(winner_two, winner_idx), winner_addr_two);
-        assert_eq(Mapping::get(winner_three, winner_idx), winner_addr_three);
-
     }
 
 

--- a/puzzle_raffle/src/main.leo
+++ b/puzzle_raffle/src/main.leo
@@ -1,4 +1,4 @@
-program puzzle_single_draw_raffle_final.aleo {
+program puzzle_raffle_052224.aleo {
     // used for storing the raffle entries (multiple entries per address)
     //   i.e. 0 -> aleo1...asdf, 1 -> aleo1...ghjk
     mapping entries: u32 => address;
@@ -379,7 +379,7 @@ program puzzle_single_draw_raffle_final.aleo {
         let has_addr_won: bool = Mapping::get_or_use(has_won, winner_address, false);
 
         // if the drawn address has already won, fail
-        assert_eq(has_addr_won, false); 
+        assert_eq(has_addr_won, false);
 
         // get the winner_count
         let current_winner_count: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);

--- a/puzzle_raffle/src/main.leo
+++ b/puzzle_raffle/src/main.leo
@@ -16,8 +16,11 @@ program puzzle_raffle_050124.aleo {
     // winner_indexes
     mapping winner_idxs: u32 => u64;
 
+    // mapping to store winner one
     mapping winner_one: u32 => address;
+    // mapping to store winner two
     mapping winner_two: u32 => address;
+    // mapping to store winner three
     mapping winner_three: u32 => address;
 
     struct PrivateKey {
@@ -376,61 +379,71 @@ program puzzle_raffle_050124.aleo {
     }
 
     finalize draw_winner () {
+        // get total entries
+        let num_entries: u64 = Mapping::get(total_entries, 0u64);
+        // grab random number
+        let random_number: u64 = ChaCha::rand_u64();
+        // select winning index
+        let winner_index: u64 = random_number % num_entries;
+        // get address at winning index
+        let winner_address: address = Mapping::get(entries, winner_index);
+        // get the winner_count
+        let current_winner_count: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);
+        // true if addr has already won, false if not
+        let has_addr_won: bool = Mapping::get_or_use(has_won, winner_address, false);
+
+        // if the winner has never been selected
+        if (has_addr_won.not()) {
+            // set addr to true {aleo1...: true}
+            Mapping::set(has_won, winner_address, true);
+            // set winner { 0u32: aleo1...} ...
+            Mapping::set(winner, current_winner_count, winner_address);
+            // increment winner count {0u32: 1u32} and so on
+            Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
+        }
+    }
+
+    // fn to draw 3 winners
+    transition draw_three_winners () {
+        assert_eq(self.caller, self.signer);
+        assert_eq(self.caller, aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw);
+        return then finalize;
+    }
+
+    finalize draw_three_winners () {
         let num_entries: u64 = Mapping::get(total_entries, 0u64);
         for i: u32 in 0u32..3u32 {
             let random_number: u64 = ChaCha::rand_u64();
             let winner_index: u64 = random_number % num_entries;
             Mapping::set(winner_idxs, i, winner_index);
         }
+
+        // grah the three random idxs
         let winner_idx_one: u64 = Mapping::get(winner_idxs, 0u32);
         let winner_idx_two: u64 = Mapping::get(winner_idxs, 1u32);
         let winner_idx_three: u64 = Mapping::get(winner_idxs, 2u32);
 
+        // get the addresses at the three random idxs
         let winner_address_one: address = Mapping::get(entries, winner_idx_one);
         let winner_address_two: address = Mapping::get(entries, winner_idx_two);
         let winner_address_three: address = Mapping::get(entries, winner_idx_three);
 
+        // assert that none of the addresses are equivalent
         assert_neq(winner_address_one, winner_address_two);
         assert_neq(winner_address_two, winner_address_three);
         assert_neq(winner_address_one, winner_address_three);
 
+        // set each winner on each mapping
         Mapping::set(winner_one, 0u32, winner_address_one);
         Mapping::set(winner_two, 0u32, winner_address_two);
         Mapping::set(winner_three, 0u32, winner_address_three);
 
     }
 
-
-    // finalize draw_winner () {
-    //     // get total entries
-    //     let num_entries: u64 = Mapping::get(total_entries, 0u64);
-    //     // grab random number
-    //     let random_number: u64 = ChaCha::rand_u64();
-    //     // select winning index
-    //     let winner_index: u64 = random_number % num_entries;
-    //     // get address at winning index
-    //     let winner_address: address = Mapping::get(entries, winner_index);
-    //     // get the winner_count
-    //     let current_winner_count: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);
-    //     // true if addr has already won, false if not
-    //     let has_addr_won: bool = Mapping::get_or_use(has_won, winner_address, false);
-
-    //     // if the winner has never been selected
-    //     if (has_addr_won.not()) {
-    //         // set addr to true {aleo1...: true}
-    //         Mapping::set(has_won, winner_address, true);
-    //         // set winner { 0u32: aleo1...} ...
-    //         Mapping::set(winner, current_winner_count, winner_address);
-    //         // increment winner count {0u32: 1u32} and so on
-    //         Mapping::set(winner_count, 0u32, current_winner_count + 1u32);
-    //     }
-    // }
-
     transition send_prize_to_winner (public winner_addr: address, public prize: Prize) -> (Prize, AuditPrizeToWinner) {
         let operator: address = aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
         assert_eq(self.caller, self.signer);
         assert_eq(self.caller, operator);
-
 
 
         let prize_to_winner: Prize = Prize {
@@ -456,6 +469,74 @@ program puzzle_raffle_050124.aleo {
     //     // assert that this function is called with the winner_addr
     //     // assert_eq(winner_addr, winner_addr_from_mapping);
     // }
+
+
+    transition send_three_prizes_to_winners(
+        public winner_addr_one: address,
+        public winner_addr_two: address,
+        public winner_addr_three: address,
+        public winner_idx: u32,
+        public prize_one: Prize,
+        public prize_two: Prize,
+        public prize_three: Prize,
+    )
+    {
+        let operator: address = aleo1pedhtu6akw9z68wedu8t3fgxfdh3ye2rypeqkx9cxjpr99chqvyqkjg7rw;
+        assert_eq(self.caller, self.signer);
+        assert_eq(self.caller, operator);
+
+        let prize_to_winner_one: Prize = Prize {
+            owner: winner_addr_one,
+            private_key: prize_one.private_key,
+        };
+
+        let audit_prize_to_winner_one: AuditPrizeToWinner = AuditPrizeToWinner {
+            owner: operator,
+            winner: winner_addr_one,
+            private_key: prize_one.private_key,
+        };
+
+        let prize_to_winner_two: Prize = Prize {
+            owner: winner_addr_two,
+            private_key: prize_two.private_key,
+        };
+
+        let audit_prize_to_winner_two: AuditPrizeToWinner = AuditPrizeToWinner {
+            owner: operator,
+            winner: winner_addr_two,
+            private_key: prize_two.private_key,
+        };
+
+        let prize_to_winner_three: Prize = Prize {
+            owner: winner_addr_three,
+            private_key: prize_three.private_key,
+        };
+
+        let audit_prize_to_winner_three: AuditPrizeToWinner = AuditPrizeToWinner {
+            owner: operator,
+            winner: winner_addr_three,
+            private_key: prize_three.private_key,
+        };
+
+
+        return then finalize (winner_addr_one, winner_addr_two, winner_addr_three, winner_idx);
+
+    }
+
+    finalize send_three_prizes_to_winners (
+        public winner_addr_one: address,
+        public winner_addr_two: address,
+        public winner_addr_three: address,
+        public winner_idx: u32,
+    )
+    {
+        // assert that the prizer are being sent to the official winners
+        assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_one);
+        assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_two);
+        assert_eq(Mapping::get(winner_one, winner_idx), winner_addr_three);
+
+    }
+
 
     // Potential future scope:
     // - pulling out of raffle

--- a/puzzle_raffle/src/main.leo
+++ b/puzzle_raffle/src/main.leo
@@ -380,9 +380,11 @@ program puzzle_raffle_050124.aleo {
         let winner_address: address = Mapping::get(entries, winner_index);
         // get the winner_count
         let current_winner_count: u32 = Mapping::get_or_use(winner_count, 0u32, 0u32);
+        // true if addr has already won, false if not
+        let has_addr_won: bool = Mapping::get_or_use(has_won, winner_address, false);
 
         // if the winner has never been selected
-        if (Mapping::get_or_use(has_won, winner_address, false)) {
+        if (has_addr_won.not()) {
             // set addr to true {aleo1...: true}
             Mapping::set(has_won, winner_address, true);
             // set winner { 0u32: aleo1...} ...

--- a/simple_sig_verify/build/main.aleo
+++ b/simple_sig_verify/build/main.aleo
@@ -16,9 +16,23 @@ record MessageSignInfo:
     message_5 as field.private;
 
 
+function mint_message:
+    input r0 as field.private;
+    input r1 as field.private;
+    input r2 as field.private;
+    input r3 as field.private;
+    input r4 as field.private;
+    cast aleo16d0pn0dyrlfs3kqaklt9lpagyjagej93lzhzps50cyxp8m9p7gqs7krdgy r0 r1 r2 r3 r4 into r5 as MessageSignInfo.record;
+    output r5 as MessageSignInfo.record;
+
+
 function sig_verify:
-    input r0 as MessageSignInfo.record;
-    input r1 as signature.private;
-    cast r0.message_1 r0.message_2 r0.message_3 r0.message_4 r0.message_5 into r2 as Message;
-    sign.verify r1 r0.owner r2 into r3;
-    output r3 as boolean.private;
+    input r0 as field.private;
+    input r1 as field.private;
+    input r2 as field.private;
+    input r3 as field.private;
+    input r4 as field.private;
+    input r5 as signature.private;
+    cast r0 r1 r2 r3 r4 into r6 as Message;
+    sign.verify r5 aleo16d0pn0dyrlfs3kqaklt9lpagyjagej93lzhzps50cyxp8m9p7gqs7krdgy r6 into r7;
+    output r7 as boolean.private;

--- a/simple_sig_verify/src/main.leo
+++ b/simple_sig_verify/src/main.leo
@@ -18,19 +18,44 @@ program simple_sig_verify.aleo {
         message_5: field,
     }
 
+    transition mint_message
+    (
+        message_1: field,
+        message_2: field,
+        message_3: field,
+        message_4: field,
+        message_5: field,
+    ) -> MessageSignInfo
+    {
+        return MessageSignInfo {
+            owner: aleo16d0pn0dyrlfs3kqaklt9lpagyjagej93lzhzps50cyxp8m9p7gqs7krdgy,
+            message_1: message_1,
+            message_2: message_2,
+            message_3: message_3,
+            message_4: message_4,
+            message_5: message_5,
+        };
+
+    }
+
     transition sig_verify(
-        message_sign_info: MessageSignInfo,
+        // message_sign_info: MessageSignInfo,
+        field_1: field,
+        field_2: field,
+        field_3: field,
+        field_4: field,
+        field_5: field,
         sig: signature
     ) -> bool {
         let msg: Message = Message {
-            field_1: message_sign_info.message_1,
-            field_2: message_sign_info.message_2,
-            field_3: message_sign_info.message_3,
-            field_4: message_sign_info.message_4,
-            field_5: message_sign_info.message_5
+            field_1: field_1,
+            field_2: field_2,
+            field_3: field_3,
+            field_4: field_4,
+            field_5: field_5
         };
 
-        let is_valid_sig: bool = sig.verify(message_sign_info.owner, msg);
+        let is_valid_sig: bool = sig.verify(aleo16d0pn0dyrlfs3kqaklt9lpagyjagej93lzhzps50cyxp8m9p7gqs7krdgy, msg);
 
         return is_valid_sig;
     }


### PR DESCRIPTION
This pr adds multiple options for our next lottery in which we will select three winners.
Option 1:

Call draw_winner multiple times until we achieve 3 unique addresses.

- Adds draw_winner that selects a winner and checks that the address has not won before.

Option 2:

Call draw_three_winners until we achieve 3 unique addresses.

- Adds draw_three_winners (attempts to fill 3 winner slots iff addresses are unique)
- Adds send_three_prizes_to_winners (sends all three prizes to each winner and checks that the addresses are the addresses selected from draw_three_winners). Also takes in the idx at which the winners were set on each respective winner mapping.

Additionally, this pr fixes and adds back in the send_prize_to_winner finalize to check that the invocation of send_prize_to_winner includes the address that has officially won.

This adds a parameter to send_prize_to_winner (the key (idx u32) at which the winner_address you are checking for exists in the winner mapping).

****Note:** We decided on option 1 for now.**